### PR TITLE
Fixed build error for UE 5.3.2

### DIFF
--- a/Source/Programs/MayaUnrealLiveLinkPlugin/BuildMayaUnrealLiveLinkPlugin.xml
+++ b/Source/Programs/MayaUnrealLiveLinkPlugin/BuildMayaUnrealLiveLinkPlugin.xml
@@ -14,11 +14,7 @@
 		<Property Name="LocalBinaryDir" Value="$(RootDir)\Engine\Restricted\NotForLicensees\Binaries\$(MayaPlatform)\Maya"/>
 		<Property Name="LocalExtraDir" Value="$(RootDir)\Engine\Restricted\NotForLicensees\Extras\MayaUnrealLiveLinkPlugin"/>
 
-		<Node Name="Compile UnrealHeaderTool Maya">
-			<Compile Target="UnrealHeaderTool" Platform="$(MayaPlatform)" Configuration="$(BuildTarget)" Arguments="-precompile -nodebuginfo"/>
-		</Node>
-
-		<Node Name="Compile Maya $(MayaVersion)" Requires="Compile UnrealHeaderTool Maya">
+		<Node Name="Compile Maya $(MayaVersion)">
 			<Compile Target="MayaUnrealLiveLinkPlugin$(MayaVersion)" Platform="$(MayaPlatform)" Configuration="$(BuildTarget)" Arguments="-noxge"/>
 			<Copy From="$(LocalSourceDir)\MayaUnrealLiveLinkPlugin.mod" To="$(LocalBinaryDir)\MayaUnrealLiveLinkPlugin.mod" />
 		</Node>

--- a/Source/Programs/MayaUnrealLiveLinkPlugin/MayaUnrealLiveLinkPlugin.cpp
+++ b/Source/Programs/MayaUnrealLiveLinkPlugin/MayaUnrealLiveLinkPlugin.cpp
@@ -2478,7 +2478,7 @@ void OnPlaybackRangeChanged(void* ClientData)
 		if (DetectIdleEvent.IsValid())
 		{
 			DetectIdleEvent->Stop();
-			DetectIdleEvent.Release();
+			DetectIdleEvent.Reset();
 		}
 
 		// Start the worker thread that will wait for additional user input before rebuilding the subjects
@@ -2700,7 +2700,7 @@ MStatus initializePlugin(MObject MayaPluginObject)
 */
 MStatus uninitializePlugin(MObject MayaPluginObject)
 {
-	DetectIdleEvent.Release();
+	DetectIdleEvent.Reset();
 
 	// Get the plugin API for the plugin object
 	MFnPlugin MayaPlugin(MayaPluginObject);

--- a/Source/Programs/MayaUnrealLiveLinkPlugin/Subjects/MLiveLinkPropSubject.cpp
+++ b/Source/Programs/MayaUnrealLiveLinkPlugin/Subjects/MLiveLinkPropSubject.cpp
@@ -22,7 +22,7 @@
 
 #include "MLiveLinkPropSubject.h"
 #include "../MayaLiveLinkStreamManager.h"
-#include "MayaUnrealLiveLinkPlugin/MayaUnrealLiveLinkUtils.h"
+#include "../MayaUnrealLiveLinkUtils.h"
 #include "LiveLinkTypes.h"
 #include "Roles/MayaLiveLinkTimelineTypes.h"
 

--- a/Source/Programs/MayaUnrealLiveLinkPlugin/UnrealInitializer/UnrealInitializer.cpp
+++ b/Source/Programs/MayaUnrealLiveLinkPlugin/UnrealInitializer/UnrealInitializer.cpp
@@ -79,6 +79,10 @@ void UnrealInitializer::InitializeUnreal()
 	// Load UdpMessaging module needed by message bus.
 	FModuleManager::Get().LoadModule(TEXT("UdpMessaging"));
 
+	IPluginManager::Get().LoadModulesForEnabledPlugins(ELoadingPhase::PreDefault);
+	IPluginManager::Get().LoadModulesForEnabledPlugins(ELoadingPhase::Default);
+	IPluginManager::Get().LoadModulesForEnabledPlugins(ELoadingPhase::PostDefault);
+
 	InitializedOnce = true;
 }
 


### PR DESCRIPTION
- remove UnrealHeaderTool from build configuration
- use Reset instead of Release for error C4834: discarding return value of function with 'nodiscard' attribute
- fixed Maya not shown in UE live link source window